### PR TITLE
Make bash invocations in shebang lines portable

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-set -x
+#!/bin/bash
+set -ex
 # This script should be run inside of a Docker container only
 if [ ! -f /.dockerinit ]; then
   echo "ERROR: script works in Docker only!"

--- a/builder/test.sh
+++ b/builder/test.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-set +x
+#!/bin/bash
+set +ex
 # This script should be run inside of a Docker container only
 if [ ! -f /.dockerinit ]; then
   echo "ERROR: script works in Docker only!"


### PR DESCRIPTION
The `-e` wouldn't work as expected for me.

See this comment for some background for this change:
rbenv/rbenv#20 (comment)