### PR TITLE
Set HYPRIOT_TAG in /etc/os-release in Travis tag build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ services:
   - docker
 language: bash
 script:
-  - make arm64
-  - make armhf
+  - HYPRIOT_TAG=${TRAVIS_TAG} make arm64
+  - HYPRIOT_TAG=${TRAVIS_TAG} make armhf
 deploy:
   provider: releases
   skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -6,28 +6,28 @@ build:
 all: build amd64 i386 arm64 armhf mips
 
 amd64: build
-	docker run --rm -e BUILD_ARCH=amd64 -v $(shell pwd):/workspace --privileged rootfs-builder
+	docker run --rm -e BUILD_ARCH=amd64 -e TRAVIS_TAG -e HYPRIOT_TAG -v $(shell pwd):/workspace --privileged rootfs-builder
 
 i386: build
-	docker run --rm -e BUILD_ARCH=i386 -v $(shell pwd):/workspace --privileged rootfs-builder
+	docker run --rm -e BUILD_ARCH=i386 -e TRAVIS_TAG -e HYPRIOT_TAG -v $(shell pwd):/workspace --privileged rootfs-builder
 
 arm64: build
-	docker run --rm -e BUILD_ARCH=arm64 -e QEMU_ARCH=aarch64 -v $(shell pwd):/workspace --privileged rootfs-builder
+	docker run --rm -e BUILD_ARCH=arm64 -e QEMU_ARCH=aarch64 -e TRAVIS_TAG -e HYPRIOT_TAG -v $(shell pwd):/workspace --privileged rootfs-builder
 
 armhf: build
-	docker run --rm -e BUILD_ARCH=armhf -e QEMU_ARCH=arm -v $(shell pwd):/workspace --privileged rootfs-builder
+	docker run --rm -e BUILD_ARCH=armhf -e QEMU_ARCH=arm -e TRAVIS_TAG -e HYPRIOT_TAG -v $(shell pwd):/workspace --privileged rootfs-builder
 
 mips: build
-	docker run --rm -e BUILD_ARCH=mips -e QEMU_ARCH=mips -v $(shell pwd):/workspace --privileged rootfs-builder
+	docker run --rm -e BUILD_ARCH=mips -e QEMU_ARCH=mips -e TRAVIS_TAG -e HYPRIOT_TAG -v $(shell pwd):/workspace --privileged rootfs-builder
 
 shell: build
-	docker run --rm -ti -v $(shell pwd):/workspace --privileged rootfs-builder bash
+	docker run --rm -ti -e TRAVIS_TAG -e HYPRIOT_TAG -v $(shell pwd):/workspace --privileged rootfs-builder bash
 
 test: build
-	docker run --rm -ti -e BUILD_ARCH=$(BUILD_ARCH) -v $(shell pwd):/workspace --privileged rootfs-builder /builder/test.sh
+	docker run --rm -ti -e BUILD_ARCH=$(BUILD_ARCH) -e TRAVIS_TAG -e HYPRIOT_TAG -v $(shell pwd):/workspace --privileged rootfs-builder /builder/test.sh
 
 testshell: build
-	docker run --rm -ti -v $(shell pwd):/workspace -v $(shell pwd)/test:/test --privileged rootfs-builder bash
+	docker run --rm -ti -e TRAVIS_TAG -e HYPRIOT_TAG -v $(shell pwd):/workspace -v $(shell pwd)/test:/test --privileged rootfs-builder bash
 
 tag:
 	git tag ${TAG}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # os-rootfs
 [![Join the chat at https://gitter.im/hypriot/talk](https://badges.gitter.im/hypriot/talk.svg)](https://gitter.im/hypriot/talk?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/hypriot/os-rootfs.svg)](https://travis-ci.org/hypriot/os-rootfs) [![Release](https://img.shields.io/github/release/hypriot/os-rootfs.svg)](https://github.com/hypriot/os-rootfs/releases)
+[![Build Status](https://travis-ci.org/hypriot/os-rootfs.svg)](https://travis-ci.org/hypriot/os-rootfs)
 
 The `os-rootfs` builds the base of all the HypriotOS images. This repo creates a general root filesystem for different CPU architectures without the board specific parts.
 

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -23,13 +23,16 @@ QEMU_ARCH="${QEMU_ARCH}"
 HYPRIOT_TAG="${HYPRIOT_TAG:-dirty}"
 ROOTFS_DIR="/debian-${BUILD_ARCH}"
 
+# Show TRAVSI_TAG in travis builds
+echo TRAVIS_TAG="${TRAVIS_TAG}"
+
 # Cleanup
 mkdir -p /workspace
 rm -fr "${ROOTFS_DIR}"
 
 # Define ARCH dependent settings
 if [ -z "${QEMU_ARCH}" ]; then
-  DEBOOTSTRAP_CMD="debootstrap"  
+  DEBOOTSTRAP_CMD="debootstrap"
 else
   DEBOOTSTRAP_CMD="qemu-debootstrap"
 

--- a/builder/test/rootfs_spec.rb
+++ b/builder/test/rootfs_spec.rb
@@ -96,7 +96,7 @@ describe file('etc/os-release') do
   it { should be_file }
   its(:content) { should contain /HYPRIOT_OS=/ }
   its(:content) { should contain /HYPRIOT_TAG=/ }
-  if ENV['TRAVIS_TAG']
+  if ENV.fetch('TRAVIS_TAG','') != ''
     its(:content) { should_not contain /dirty/ }
   end
 end

--- a/builder/test/rootfs_spec.rb
+++ b/builder/test/rootfs_spec.rb
@@ -96,6 +96,9 @@ describe file('etc/os-release') do
   it { should be_file }
   its(:content) { should contain /HYPRIOT_OS=/ }
   its(:content) { should contain /HYPRIOT_TAG=/ }
+  if ENV['TRAVIS_TAG']
+    its(:content) { should_not contain /dirty/ }
+  end
 end
 
 describe "Firstboot Systemd Service" do


### PR DESCRIPTION
The v0.6.0 rootfs has HYPRIOT_TAG=dirty. This PR fixes it. Travis will add right tag version into /etc/os-release and test it that the file does not contain `dirty` before deploying to GitHub release.

For local builds and Contributors and PR's the extra test for `dirty` will be skipped as this artifact won't be deployed.
