### PR TITLE
Run firstboot once

### DIFF
--- a/builder/files/lib/systemd/system/hypriot-firstboot.service
+++ b/builder/files/lib/systemd/system/hypriot-firstboot.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=run task that need to be run on first boot only
+ConditionPathExists=!/etc/hypriot-firstboot_not_to_be_run
 
 [Service]
 Type=oneshot

--- a/builder/files/usr/local/bin/hypriot-firstboot
+++ b/builder/files/usr/local/bin/hypriot-firstboot
@@ -1,10 +1,9 @@
 #!/bin/bash
 set -ex
 
-
 for file in /etc/firstboot.d/*; do
   source "$file"
 done
 
 # do not run firstboot scripts after first time again
-systemctl disable hypriot-firstboot.service
+touch /etc/hypriot-firstboot_not_to_be_run

--- a/builder/test/rootfs_spec.rb
+++ b/builder/test/rootfs_spec.rb
@@ -137,4 +137,8 @@ describe "Firstboot Systemd Service" do
     expect(script).to exist
   end
 
+  describe file('etc/hypriot-firstboot_not_to_be_run') do
+    it { should_not be_file }
+  end
+
 end


### PR DESCRIPTION
I investigated the firstboot script many times, but even after disabling the service manually it still starts after a reboot and then is still disabled.

I compared how sshd disables and found a solution with

 ```
ConditionPathExists=!/etc/hypriot-firstboot_not_to_be_run
```

Rebooting a RPi only shows the message `localhost systemd[1]: Started run task that need to be run on first boot only.` but the script is no longer called.

Fixes #14 