### PR TITLE
Make /etc/os-release compatible with docker-machine

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -56,6 +56,10 @@ echo "$HYPRIOT_USERNAME:$HYPRIOT_PASSWORD" | /usr/sbin/chpasswd
 echo "$HYPRIOT_USERNAME ALL=NOPASSWD: ALL" > "/etc/sudoers.d/user-$HYPRIOT_USERNAME"
 chmod 0440 "/etc/sudoers.d/user-$HYPRIOT_USERNAME"
 
+# make /etc/os-release compatible with docker-machine
+echo "Making /etc/os-release compatible with docker-machine"
+sed -i 's/ID=raspbian/ID=debian/' /usr/lib/os-release
+
 # set HypriotOS version infos
 echo "HYPRIOT_OS=\"HypriotOS/${BUILD_ARCH}\"" >> /etc/os-release
 echo "HYPRIOT_OS_VERSION=\"${HYPRIOT_OS_VERSION}\"" >> /etc/os-release

--- a/builder/test/rootfs_spec.rb
+++ b/builder/test/rootfs_spec.rb
@@ -117,6 +117,7 @@ end
 
 describe file('etc/os-release') do
   it { should be_file }
+  its(:content) { should contain /ID=debian/ }
   its(:content) { should contain /HYPRIOT_OS=/ }
   its(:content) { should contain /HYPRIOT_OS_VERSION=/ }
   if ENV.fetch('TRAVIS_TAG','') != ''


### PR DESCRIPTION
This commit changes the /etc/os-release file to contain `ID=debian` to make it compatible with orginal docker-machine binary.

Fixes #36 
