### PR TITLE
Use hypriot/image-builder base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,11 @@
-FROM debian:jessie
+FROM hypriot/image-builder:latest
 
 RUN apt-get update && apt-get install -y \
+    binfmt-support \
     qemu \
     qemu-user-static \
-    binfmt-support \
-    debootstrap \
-    elfutils \
-    ruby \
-    shellcheck \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
-
-RUN gem update --no-document --system && \
-    gem install --no-document serverspec
 
 COPY builder /builder/
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 default: build
 
 build:
-	docker build -t rootfs-builder . || true
 	docker build -t rootfs-builder .
 
 all: build amd64 i386 arm64-debian armhf-debian mips armhf-raspbian


### PR DESCRIPTION
To avoid problems with httpredir.debian.org use a Docker base image hypriot/image-builder with the preinstalled tools.