### PR TITLE
Switch back to ID=raspbian in /etc/os-release

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -58,10 +58,6 @@ echo "$HYPRIOT_USERNAME:$HYPRIOT_PASSWORD" | /usr/sbin/chpasswd
 echo "$HYPRIOT_USERNAME ALL=NOPASSWD: ALL" > "/etc/sudoers.d/user-$HYPRIOT_USERNAME"
 chmod 0440 "/etc/sudoers.d/user-$HYPRIOT_USERNAME"
 
-# make /etc/os-release compatible with docker-machine
-echo "Making /etc/os-release compatible with docker-machine"
-sed -i 's/ID=raspbian/ID=debian/' /usr/lib/os-release
-
 # set HypriotOS version infos
 echo "HYPRIOT_OS=\"HypriotOS/${BUILD_ARCH}\"" >> /etc/os-release
 echo "HYPRIOT_OS_VERSION=\"${HYPRIOT_OS_VERSION}\"" >> /etc/os-release

--- a/builder/test/rootfs_spec.rb
+++ b/builder/test/rootfs_spec.rb
@@ -117,7 +117,12 @@ end
 
 describe file('etc/os-release') do
   it { should be_file }
-  its(:content) { should contain /ID=debian/ }
+  if ENV['VARIANT'] == 'raspbian'
+    its(:content) { should contain /ID=raspbian/ }
+    its(:content) { should contain /ID_LIKE=debian/ }
+  else
+    its(:content) { should contain /ID=debian/ }
+  end
   its(:content) { should contain /HYPRIOT_OS=/ }
   its(:content) { should contain /HYPRIOT_OS_VERSION=/ }
   if ENV.fetch('TRAVIS_TAG','') != ''


### PR DESCRIPTION
In order to make HypriotOS for RPi compatible with Docker Machine, we had to modify the ID from
`raspbian` to `debian` in the past. This was just a hack which should be obsolete as soon as the new raspbian provisioner will be merged into Docker Machine with this PR https://github.com/docker/machine/pull/3605.

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>