### PR TITLE
Add /sbin dirs to user pirate's PATH

### DIFF
--- a/builder/files/etc/skel/.profile
+++ b/builder/files/etc/skel/.profile
@@ -1,5 +1,10 @@
 # ~/.profile: executed by Bourne-compatible login shells.
 
+if [ "$USER" == "pirate" ]; then
+  PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games"
+  export PATH
+fi
+
 if [ "$BASH" ]; then
   if [ -f ~/.bashrc ]; then
     . ~/.bashrc
@@ -13,6 +18,7 @@ fi
 # set PATH so it includes GO bin if it exists
 if [ -d "/usr/local/go/bin" ] ; then
   PATH="/usr/local/go/bin:$PATH"
+  export PATH
 fi
 
 mesg n


### PR DESCRIPTION
Add the /sbin dirs to the standard PATH of the user `pirate`, which is the same behaviour as the user `pi` on Raspbian. Resolves https://github.com/hypriot/image-builder-rpi/issues/107.

I just made this extension within the new user skeleton files and the change is restricted to user name `pirate`.

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>