### PR TITLE
Expose more configuration variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+DEFAULT_OPTS=-e HYPRIOT_HOSTNAME -e HYPRIOT_GROUPNAME -e HYPRIOT_USERNAME -e HYPRIOT_PASSWORD
+
 default: build
 
 build:
@@ -6,28 +8,28 @@ build:
 all: build amd64 i386 arm64-debian armhf-debian mips armhf-raspbian
 
 amd64: build
-	docker run --rm -e BUILD_ARCH=amd64 -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -v $(shell pwd):/workspace --privileged rootfs-builder
+	docker run --rm $(DEFAULT_OPTS) -e BUILD_ARCH=amd64 -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -v $(shell pwd):/workspace --privileged rootfs-builder
 
 i386: build
-	docker run --rm -e BUILD_ARCH=i386 -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -v $(shell pwd):/workspace --privileged rootfs-builder
+	docker run --rm $(DEFAULT_OPTS) -e BUILD_ARCH=i386 -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -v $(shell pwd):/workspace --privileged rootfs-builder
 
 arm64-debian: build
-	docker run --rm -e BUILD_ARCH=arm64 -e QEMU_ARCH=aarch64 -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -v $(shell pwd):/workspace --privileged rootfs-builder
+	docker run --rm $(DEFAULT_OPTS) -e BUILD_ARCH=arm64 -e QEMU_ARCH=aarch64 -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -v $(shell pwd):/workspace --privileged rootfs-builder
 
 armhf-debian: build
-	docker run --rm -e BUILD_ARCH=armhf -e QEMU_ARCH=arm -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -v $(shell pwd):/workspace --privileged rootfs-builder
+	docker run --rm $(DEFAULT_OPTS) -e BUILD_ARCH=armhf -e QEMU_ARCH=arm -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -v $(shell pwd):/workspace --privileged rootfs-builder
 
 armhf-raspbian: build
-	docker run --rm -e BUILD_ARCH=armhf -e QEMU_ARCH=arm -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -e VARIANT=raspbian -v $(shell pwd):/workspace --privileged rootfs-builder
+	docker run --rm $(DEFAULT_OPTS) -e BUILD_ARCH=armhf -e QEMU_ARCH=arm -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -e VARIANT=raspbian -v $(shell pwd):/workspace --privileged rootfs-builder
 
 mips: build
-	docker run --rm -e BUILD_ARCH=mips -e QEMU_ARCH=mips -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -v $(shell pwd):/workspace --privileged rootfs-builder
+	docker run --rm $(DEFAULT_OPTS) -e BUILD_ARCH=mips -e QEMU_ARCH=mips -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -v $(shell pwd):/workspace --privileged rootfs-builder
 
 shell: build
 	docker run --rm -ti -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -v $(shell pwd):/workspace --privileged rootfs-builder bash
 
 test: build
-	docker run --rm -ti -e BUILD_ARCH=$(BUILD_ARCH) -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -e VARIANT -v $(shell pwd):/workspace --privileged rootfs-builder /builder/test.sh
+	docker run --rm -ti $(DEFAULT_ENV) -e BUILD_ARCH=$(BUILD_ARCH) -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -e VARIANT -v $(shell pwd):/workspace --privileged rootfs-builder /builder/test.sh
 
 testshell: build
 	docker run --rm -ti -e TRAVIS_TAG -e HYPRIOT_OS_VERSION -v $(shell pwd):/workspace -v $(shell pwd)/test:/test --privileged rootfs-builder bash

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -9,10 +9,10 @@ if [ ! -f /.dockerenv ]; then
 fi
 
 # Hypriot common settings
-HYPRIOT_HOSTNAME="black-pearl"
-HYPRIOT_GROUPNAME="docker"
-HYPRIOT_USERNAME="pirate"
-HYPRIOT_PASSWORD="hypriot"
+HYPRIOT_HOSTNAME="${HYPRIOT_HOSTNAME:-black-pearl}"
+HYPRIOT_GROUPNAME="${HYPRIOT_GROUPNAME:-docker}"
+HYPRIOT_USERNAME="${HYPRIOT_USERNAME:-pirate}"
+HYPRIOT_PASSWORD="${HYPRIOT_PASSWORD:-hypriot}"
 
 # build Debian rootfs for ARCH={armhf,arm64,mips,i386,amd64}
 # - Debian armhf = ARMv6/ARMv7
@@ -89,10 +89,10 @@ mount -t sysfs none "$ROOTFS_DIR/sys"
 # docker tools and some customizations
 chroot "$ROOTFS_DIR" \
        /usr/bin/env \
-       HYPRIOT_HOSTNAME=$HYPRIOT_HOSTNAME \
-       HYPRIOT_GROUPNAME=$HYPRIOT_GROUPNAME \
-       HYPRIOT_USERNAME=$HYPRIOT_USERNAME \
-       HYPRIOT_PASSWORD=$HYPRIOT_PASSWORD \
+       HYPRIOT_HOSTNAME="$HYPRIOT_HOSTNAME" \
+       HYPRIOT_GROUPNAME="$HYPRIOT_GROUPNAME" \
+       HYPRIOT_USERNAME="$HYPRIOT_USERNAME" \
+       HYPRIOT_PASSWORD="$HYPRIOT_PASSWORD" \
        HYPRIOT_OS_VERSION="$HYPRIOT_OS_VERSION" \
        BUILD_ARCH="$BUILD_ARCH" \
        VARIANT="$VARIANT" \
@@ -117,4 +117,4 @@ sha256sum "${ARCHIVE_NAME}" > "${ARCHIVE_NAME}.sha256"
 cd -
 
 # test if rootfs is OK
-VARIANT="${VARIANT}" /builder/test.sh
+HYPRIOT_HOSTNAME="${HYPRIOT_HOSTNAME}" HYPRIOT_GROUPNAME="${HYPRIOT_GROUPNAME}" HYPRIOT_USERNAME="${HYPRIOT_USERNAME}" HYPRIOT_PASSWORD="${HYPRIOT_PASSWORD}" VARIANT="${VARIANT}" /builder/test.sh

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -47,6 +47,7 @@ dpkg-reconfigure -f noninteractive locales
 echo "$HYPRIOT_HOSTNAME" > /etc/hostname
 
 # install skeleton files from /etc/skel for root user
+sed -i -- "s/pirate/$HYPRIOT_USERNAME/g" /etc/skel/.profile
 cp /etc/skel/{.bash_prompt,.bashrc,.profile} /root/
 
 # install Hypriot group and user

--- a/builder/test/rootfs_spec.rb
+++ b/builder/test/rootfs_spec.rb
@@ -59,29 +59,29 @@ end
 
 describe file('etc/hostname') do
   it { should be_file }
-  its(:content) { should contain /^black-pearl$/ }
+  its(:content) { should contain /^#{ENV['HYPRIOT_HOSTNAME']}$/ }
 end
 
 describe file('etc/group') do
   it { should be_file }
-  its(:content) { should contain /^docker:x:.*:pirate/ }
-  its(:content) { should contain /^pirate:x:/ }
+  its(:content) { should contain /^#{ENV['HYPRIOT_GROUPNAME']}:x:.*:#{ENV['HYPRIOT_USERNAME']}/ }
+  its(:content) { should contain /^#{ENV['HYPRIOT_USERNAME']}:x:/ }
 end
 
 describe file('etc/passwd') do
   it { should be_file }
-  its(:content) { should contain /^pirate:/ }
+  its(:content) { should contain /^#{ENV['HYPRIOT_USERNAME']}:/ }
 end
 
 describe file('etc/shadow') do
   it { should be_file }
-  its(:content) { should contain /^pirate:/ }
+  its(:content) { should contain /^#{ENV['HYPRIOT_USERNAME']}:/ }
 end
 
-describe file('etc/sudoers.d/user-pirate') do
+describe file("etc/sudoers.d/user-#{ENV['HYPRIOT_USERNAME']}") do
   it { should be_file }
   it { should be_mode 440 }
-  its(:content) { should contain /^pirate ALL=NOPASSWD: ALL$/ }
+  its(:content) { should contain /^#{ENV['HYPRIOT_USERNAME']} ALL=NOPASSWD: ALL$/ }
 end
 
 describe file('root/.bash_prompt') do


### PR DESCRIPTION
Host configuration could be easier to tweak without having to
edit scripts.
`HYPRIOT_HOSTNAME`, `HYPRIOT_GROUPNAME`, `HYPRIOT_USERNAME`
and `HYPRIOT_PASSWORD` can be changed using environment variables.

For instance `HYPRIOT_USERNAME=theuser HYPRIOT_PASSWORD=thepass
HYPRIOT_HOSTNAME=thehost make armhf-raspbian`.