### PR TITLE
use \$ in bash PS1, fixes #49

### DIFF
--- a/builder/files/etc/skel/.bash_prompt
+++ b/builder/files/etc/skel/.bash_prompt
@@ -3,7 +3,7 @@
 
 default_username='unknown'
 OSNAME="HypriotOS: "
-PROMPTCHAR="\$"
+PROMPTCHAR='\$'
 
 # determine OS type
 if [ "$(uname -s)" = Darwin ]; then

--- a/builder/files/etc/skel/.bash_prompt
+++ b/builder/files/etc/skel/.bash_prompt
@@ -88,7 +88,7 @@ function usernamehost() {
 # \[\e]1;\]$(basename $(dirname $PWD))/\W\[\a\]
 
 
-# show git infos only on macOS, don't slow down on ARM devices
+# show git info only on macOS, don't slow down on ARM devices
 if [ "$(uname -s)" = Darwin ]; then
   PS1="\[\e]2;$PWD\[\a\]\[\e]1;\]$(basename "$(dirname "$PWD")")/\W\[\a\]${BOLD}$(usernamehost)\[$GREEN\]\w\$(git_info)\[$RESET\]\[$BOLD\]\n${PROMPTCHAR} \[$RESET\]"
 else


### PR DESCRIPTION
from [bash manual](https://www.gnu.org/software/bash/manual/bashref.html#Controlling-the-Prompt):

> \$
> If the effective uid is `0`, `#`, otherwise `$`.

so, `PS1` needs to contain `\$` literally, if inside double quoted as `PROMPTCHAR="\\\$"`

fixes #49
