### PR TITLE
Fix version info for Debian Stretch

### DIFF
--- a/builder/files/etc/issue
+++ b/builder/files/etc/issue
@@ -1,2 +1,2 @@
-HypriotOS (Debian GNU/Linux 8) \n \l
+HypriotOS (Debian GNU/Linux 9) \n \l
 

--- a/builder/files/etc/issue.net
+++ b/builder/files/etc/issue.net
@@ -1,1 +1,1 @@
-HypriotOS (Debian GNU/Linux 8)
+HypriotOS (Debian GNU/Linux 9)

--- a/builder/files/etc/motd
+++ b/builder/files/etc/motd
@@ -1,5 +1,5 @@
 
-HypriotOS (Debian GNU/Linux 8)
+HypriotOS (Debian GNU/Linux 9)
 
 The programs included with the Debian GNU/Linux system are free software;
 the exact distribution terms for each program are described in the


### PR DESCRIPTION
- now it's `HypriotOS (Debian GNU/Linux 9)`

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>