### PR TITLE
Add less and dirmngr packages

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -24,7 +24,7 @@ HYPRIOT_OS_VERSION="${HYPRIOT_OS_VERSION:-dirty}"
 ROOTFS_DIR="/debian-${BUILD_ARCH}"
 DEBOOTSTRAP_URL="http://ftp.debian.org/debian"
 DEBOOTSTRAP_KEYRING_OPTION=""
-DEFAULT_PACKAGES_INCLUDE="apt-transport-https,avahi-daemon,bash-completion,binutils,ca-certificates,curl,git-core,htop,locales,net-tools,ntp,openssh-server,parted,sudo,usbutils,wget,libpam-systemd"
+DEFAULT_PACKAGES_INCLUDE="apt-transport-https,avahi-daemon,bash-completion,binutils,ca-certificates,curl,git-core,htop,locales,net-tools,ntp,openssh-server,parted,sudo,usbutils,wget,libpam-systemd,less,dirmngr"
 DEFAULT_PACKAGES_EXCLUDE="debfoster"
 
 if [[ "${VARIANT}" = "raspbian" ]]; then


### PR DESCRIPTION
Fixes #64

Tested locally an an RPI3 with [user-data.yml](https://github.com/ecliptik/rpi/blob/master/hypriot/user-data.yml) that was failing in https://github.com/DieterReuter/image-builder-rpi64/issues/56 and apt GPG keys are added correctly.

Signed-off-by: Micheal Waltz <ecliptik@gmail.com>