### PR TITLE
Update to raspbian.raspberrypi.org

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -28,12 +28,12 @@ DEFAULT_PACKAGES_INCLUDE="apt-transport-https,avahi-daemon,bash-completion,binut
 DEFAULT_PACKAGES_EXCLUDE="debfoster"
 
 if [[ "${VARIANT}" = "raspbian" ]]; then
-  DEBOOTSTRAP_URL="http://mirrordirector.raspbian.org/raspbian/"
+  DEBOOTSTRAP_URL="http://raspbian.raspberrypi.org/raspbian/"
   DEBOOTSTRAP_KEYRING_OPTION="--keyring=/etc/apt/trusted.gpg"
 
   # for Raspbian we need an extra gpg key to be able to access the repository
   mkdir -p /builder/files/tmp
-  wget -v -O "/builder/files/tmp/raspbian.public.key" http://mirrordirector.raspbian.org/raspbian.public.key
+  wget -v -O "/builder/files/tmp/raspbian.public.key" http://raspbian.raspberrypi.org/raspbian.public.key
   get_gpg A0DA38D0D76E8B5D638872819165938D90FDDD2E "/builder/files/tmp/raspbian.public.key"
 
 fi

--- a/builder/files/etc/apt/sources.list.raspbian.stretch
+++ b/builder/files/etc/apt/sources.list.raspbian.stretch
@@ -1,3 +1,3 @@
-deb http://mirrordirector.raspbian.org/raspbian/ stretch main contrib non-free rpi
+deb http://raspbian.raspberrypi.org/raspbian/ stretch main contrib non-free rpi
 # Uncomment line below then 'apt-get update' to enable 'apt-get source'
-#deb-src http://archive.raspbian.org/raspbian/ stretch main contrib non-free rpi
+#deb-src http://raspbian.raspberrypi.org/raspbian/ stretch main contrib non-free rpi

--- a/builder/test/rootfs_spec.rb
+++ b/builder/test/rootfs_spec.rb
@@ -16,7 +16,7 @@ end
 if ENV['VARIANT'] == 'raspbian'
   describe file('etc/apt/sources.list') do
     it { should be_file }
-    its(:content) { should contain 'deb http://mirrordirector.raspbian.org/raspbian/ stretch main contrib non-free rpi' }
+    its(:content) { should contain 'deb http://raspbian.raspberrypi.org/raspbian/ stretch main contrib non-free rpi' }
   end
 elsif ENV['VARIANT'] == 'debian'
   describe file('etc/apt/sources.list') do


### PR DESCRIPTION
Today I got many CircleCI build errors:
```
+ apt-get install -y --no-install-recommends lsb-release gettext
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package lsb-release
E: Unable to locate package gettext
```

Found this commit https://github.com/RPi-Distro/pi-gen/commit/93db3736721d968a6ab67d37243d6f3aa6958d00 in https://github.com/RPi-Distro/pi-gen/issues/174
